### PR TITLE
Adding a new apt-get install for php7.2-sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 # Install PHP
-RUN apt-get update && apt-get install -y php7.2-fpm php7.2-bcmath php7.2-cli php7.2-curl php7.2-mysql php7.2-mbstring php7.2-dom php7.2-xdebug php7.2-tidy php7.2-gd php7.2-zip php7.2-imap php7.2-soap && \
+RUN apt-get update && apt-get install -y php7.2-fpm php7.2-bcmath php7.2-cli php7.2-curl php7.2-mysql php7.2-mbstring php7.2-dom php7.2-xdebug php7.2-tidy php7.2-gd php7.2-zip php7.2-imap php7.2-soap php7.2-sqlite && \
     php -m
 
 # Install Node.js


### PR DESCRIPTION
I'm trying to use this image to test out a build pipeline. Unfortunately it's failing since I have my tests using an in-memory sqlite database. Seems like I'm just missing this package to get me up and running. I would greatly appreciate you merging this in. 