### PR TITLE
Upgrade php to 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,22 +47,22 @@ RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 RUN apt-get update \
     && apt-get install -y \
     php-redis \
-    php8.1-bcmath \
-    php8.1-cli \
-    php8.1-curl \
-    php8.1-dom \
-    php8.1-fpm \
-    php8.1-gd \
-    php8.1-imap \
-    php8.1-intl \
-    php8.1-ldap \
-    php8.1-mbstring \
-    php8.1-mysql \
-    php8.1-soap \
-    php8.1-sqlite \
-    php8.1-tidy \
-    php8.1-xdebug \
-    php8.1-zip \
+    php8.2-bcmath \
+    php8.2-cli \
+    php8.2-curl \
+    php8.2-dom \
+    php8.2-fpm \
+    php8.2-gd \
+    php8.2-imap \
+    php8.2-intl \
+    php8.2-ldap \
+    php8.2-mbstring \
+    php8.2-mysql \
+    php8.2-soap \
+    php8.2-sqlite \
+    php8.2-tidy \
+    php8.2-xdebug \
+    php8.2-zip \
     && php -m \
     && php -v
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Based on Debian 11 (bullseye)
 
 ## Features
-+ PHP 8.1
++ PHP 8.2
 + Composer 2
 + Node.js 16
 + npm 8


### PR DESCRIPTION
Not really sure about `php-redis` package. Could not find `php8.2-redis` package, but it does exist for 8.1..